### PR TITLE
fix warning of redundant import

### DIFF
--- a/src/System/Hardware/WiringPi.hs
+++ b/src/System/Hardware/WiringPi.hs
@@ -57,7 +57,6 @@ module System.Hardware.WiringPi
   , wiringPiISR
   ) where
 
-import Control.Applicative
 import Control.Exception ( evaluate )
 import Control.Monad ( when )
 import Data.Ord ( comparing )


### PR DESCRIPTION
## Before

```
$ cabal build
Building wiringPi-1.0...
Preprocessing library wiringPi-1.0...
[3 of 3] Compiling System.Hardware.WiringPi ( src/System/Hardware/WiringPi.hs, dist/build/System/Hardware/WiringPi.o )

src/System/Hardware/WiringPi.hs:60:1: warning: [-Wunused-imports]
    The import of ‘Control.Applicative’ is redundant
      except perhaps to import instances from ‘Control.Applicative’
    To import instances alone, use: import Control.Applicative()
Preprocessing executable 'pwm-example' for wiringPi-1.0...
Linking dist/build/pwm-example/pwm-example ...
Preprocessing executable 'isr-example' for wiringPi-1.0...
Linking dist/build/isr-example/isr-example ...
Preprocessing executable 'output-example' for wiringPi-1.0...
Linking dist/build/output-example/output-example ...
Preprocessing executable 'write-byte-example' for wiringPi-1.0...
Linking dist/build/write-byte-example/write-byte-example ...
Preprocessing executable 'turn-off' for wiringPi-1.0...
Linking dist/build/turn-off/turn-off ...
Preprocessing executable 'wiringPi-test' for wiringPi-1.0...
Linking dist/build/wiringPi-test/wiringPi-test ...
```

## After

```
$ cabal build
Building wiringPi-1.0...
Preprocessing library wiringPi-1.0...
[3 of 3] Compiling System.Hardware.WiringPi ( src/System/Hardware/WiringPi.hs, dist/build/System/Hardware/WiringPi.o )
Preprocessing executable 'pwm-example' for wiringPi-1.0...
Linking dist/build/pwm-example/pwm-example ...
Preprocessing executable 'isr-example' for wiringPi-1.0...
Linking dist/build/isr-example/isr-example ...
Preprocessing executable 'output-example' for wiringPi-1.0...
Linking dist/build/output-example/output-example ...
Preprocessing executable 'write-byte-example' for wiringPi-1.0...
Linking dist/build/write-byte-example/write-byte-example ...
Preprocessing executable 'turn-off' for wiringPi-1.0...
Linking dist/build/turn-off/turn-off ...
Preprocessing executable 'wiringPi-test' for wiringPi-1.0...
Linking dist/build/wiringPi-test/wiringPi-test ...
```